### PR TITLE
#45 エラーメッセージの表示幅変更

### DIFF
--- a/resources/views/error_card_list.blade.php
+++ b/resources/views/error_card_list.blade.php
@@ -1,5 +1,5 @@
 @if ($errors->any())
-    <div class="card-text text-left alert alert-danger">
+    <div class="col-xs-12 col-sm-12 col-md-10 col-lg-10 mx-auto card-text text-left alert alert-danger">
         <ul class="mb-0">
             @foreach ($errors->all() as $error)
                 <li>{{ $error }}</li>


### PR DESCRIPTION
エラーメッセージの幅が広すぎたので修正

resources/views/error_card_list.blade.php

のdivタグに

col-xs-12 col-sm-12 col-md-10 col-lg-10 mx-auto

classを付与