### PR TITLE
deploy to heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "watch-poll": "npm run watch -- --watch-poll",
         "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
         "prod": "npm run production",
-        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "postinstall": "npm ci"
     },
     "devDependencies": {
         "axios": "^0.19",


### PR DESCRIPTION
npm install 時にnpm ciを自動で実行するように
package.jsonに
"scripts": {
  "postinstall": "npm run production"
}